### PR TITLE
adding directory functionality for remove request within config.json

### DIFF
--- a/hpss.js
+++ b/hpss.js
@@ -201,19 +201,39 @@ var removeid = 0;
 var removed = 0;
 if(config.remove) async.eachSeries(config.remove, function(del, next) {
     if(!del.hpsspath) return next("hpsspath not set for remove request");
-
-    context.rm(del.hpsspath, function(err, out) {
-        var key = ".remove_"+(removeid++);
-        if(err) {
-            console.error(err);
-            progress(key, {status: "failed", msg: "Failed to remove a file:"+del.hpsspath}, function() {
-                next(); //skip this file and continue with other files
+    if (del.directory) {
+	context.rmdir(del.hpsspath, function(err, out) {
+                var key = ".remove_"+(removeid++);
+		var dir_msg = "Directory not empty";
+                if(err && !err.includes(dir_msg)) {
+                    console.error(err);
+                    progress(key, {status: "failed", msg: "Failed to remove a directory:"+del.hpsspath}, function() {
+                            next(); //skip this directory  and continue with other files
+			});
+                } else {
+		    var message = "Removed Dir ";
+		    if (err && err.includes(dir_msg)) {
+			message = dir_msg+" (skipping) ";
+		    }
+                    removed++;
+                    progress(key, {status: "finished", progress: 1, msg: message+del.hpsspath}, next);
+                }
             });
-        } else {
-            removed++;
-            progress(key, {status: "finished", progress: 1, msg: "Removed "+del.hpsspath}, next);
-        }
-    });
+    }
+    else {
+	context.rm(del.hpsspath, function(err, out) {
+		var key = ".remove_"+(removeid++);
+		if(err) {
+		    console.error(err);
+		    progress(key, {status: "failed", msg: "Failed to remove a file:"+del.hpsspath}, function() {
+			    next(); //skip this file and continue with other files
+			});
+		} else {
+		    removed++;
+		    progress(key, {status: "finished", progress: 1, msg: "Removed "+del.hpsspath}, next);
+		}
+	    });
+    }
 }, function(err) {
     //create empty products.json
     fs.writeFile("products.json", JSON.stringify([]), function(err) {


### PR DESCRIPTION
These modifications implement directory remove functionality in hpss.js. Initiate this by setting config.remove equal to the following (i.e. add "directory": true): 

[{"hpsspath":".daart-archive/project_dir/[id].tar.gz"}, {"hpsspath":".daart-archive/project_dir","directory":true}]

This facilitates the ability to delete DAART archives that have been grouped into project sub-directories. This will remove the project sub-directory only if there are no more archives within the sub-directory. Note: directories on HPSS will not be deleted unless they are empty. If they are not empty.. I display a skip message (not a failure). 